### PR TITLE
Use contains() instead of equals() for blacklist

### DIFF
--- a/src/main/java/me/darkolythe/shulkerpacks/ShulkerListener.java
+++ b/src/main/java/me/darkolythe/shulkerpacks/ShulkerListener.java
@@ -77,7 +77,7 @@ public class ShulkerListener implements Listener {
             }
 
             for (String str: main.blacklist) {
-                if (ChatColor.translateAlternateColorCodes('&', str).equals(player.getOpenInventory().getTitle())) {
+                if (player.getOpenInventory().getTitle().contains(ChatColor.translateAlternateColorCodes('&', str))) {
                     return;
                 }
             }


### PR DESCRIPTION
Useful for blacklisting all auction pages when using CrazyAuctions
tested working