### PR TITLE
Respect other plugins cancelling the InventoryClickEvent

### DIFF
--- a/src/main/java/me/darkolythe/shulkerpacks/ShulkerListener.java
+++ b/src/main/java/me/darkolythe/shulkerpacks/ShulkerListener.java
@@ -46,6 +46,10 @@ public class ShulkerListener implements Listener {
      */
     @EventHandler
     public void onInventoryClick(InventoryClickEvent event) {
+    	if (event.isCancelled()) {
+    		return;
+    	}
+    	
         Player player = (Player) event.getWhoClicked();
 
         if (main.openshulkers.containsKey(player)) {


### PR DESCRIPTION
Respect other plugins cancelling the InventoryClickEvent so that item in "display" type inventory (menus etc.) do not open up shulker boxes and create potential duping.