### PR TITLE
Fixed dupe

### DIFF
--- a/src/main/java/me/darkolythe/shulkerpacks/ShulkerListener.java
+++ b/src/main/java/me/darkolythe/shulkerpacks/ShulkerListener.java
@@ -105,6 +105,9 @@ public class ShulkerListener implements Listener {
             if (player.getInventory() == event.getClickedInventory() && !main.canopenininventory) {
             	return;
             }
+            if (event.getSlotType() == InventoryType.SlotType.RESULT) {
+                return;
+            }
             if(event.getClickedInventory() != null && event.getClickedInventory().getHolder() != null && event.getClickedInventory().getHolder().getClass().toString().endsWith(".CraftBarrel") && !main.canopeninbarrels) {
             	return;
             }


### PR DESCRIPTION
When right clicking the resulting shulker chest in the crafting menu.
Related to this issue: https://github.com/christopherwalkerml/ShulkerPacks/issues/9

Returning if the InventoryClickEvent is the result slot of a crafting inventory.